### PR TITLE
Add cancel transaction and enable parameter-less method

### DIFF
--- a/libs/compiler/src/compilerWorker.ts
+++ b/libs/compiler/src/compilerWorker.ts
@@ -154,7 +154,16 @@ export class CompilerHost {
                                         normalizedEntryFile += `${node.getFullText().trim()}\n`;
                                     }
                                 } else {
-                                    normalizedEntryFile += `${node.getFullText().trim()}\n`;
+                                    const mangledName = `${deferredMarker}${node.name.text}`;
+                                    normalizedEntryFile += `${node.getFullText()
+                                        // TODO - Understand if we should keep the export keyword
+                                        // .replace('export function', 'function')
+                                        .replace(node.name.text, mangledName)
+                                        .trim()}\n`;
+                                    normalizedEntryFile += `
+                                        export function ${node.name.text}(_no_args_: i32): void {
+                                            return ${mangledName}();
+                                        }`;
                                 }
                             } else {
                                 normalizedEntryFile += `${node.getFullText().trim()}\n`;

--- a/libs/sdk/assembly/index.ts
+++ b/libs/sdk/assembly/index.ts
@@ -77,6 +77,9 @@ declare function start_recording(): i32;
 // @ts-ignore: decorator
 @external("env", "stop_recording")
 declare function stop_recording(): i32;
+// @ts-ignore: decorator
+@external("env", "cancel_transaction")
+declare function cancel_transaction(): i32;
 
 
 
@@ -185,6 +188,13 @@ export class Subscription {
 
     static setReplayStop(): i32 {
         return stop_recording();
+    }
+}
+
+export class Transaction
+{
+    static cancel(): i32 {
+        return cancel_transaction();
     }
 }
 


### PR DESCRIPTION
- **Feat:** Add cancel-transaction method in asc sdk
- **Fix:** Enable parameter-less user defined method management in non-interpreted wasm runtime.